### PR TITLE
Only flash led in PCIeSoC.

### DIFF
--- a/netv2_base.py
+++ b/netv2_base.py
@@ -128,11 +128,6 @@ class BaseSoC(SoCSDRAM):
         checker_port = self.sdram.crossbar.get_port(mode="read")
         self.submodules.checker = LiteDRAMBISTChecker(checker_port)
 
-        # led blink
-        counter = Signal(32)
-        self.sync.clk125 += counter.eq(counter + 1)
-        self.comb += platform.request("user_led", 0).eq(counter[26])
-
 
 def main():
     parser = argparse.ArgumentParser(description="NeTV2 LiteX Base SoC")

--- a/netv2_pcie.py
+++ b/netv2_pcie.py
@@ -55,6 +55,11 @@ class PCIeDMASoC(BaseSoC):
         for k, v in sorted(self.interrupts.items()):
             self.comb += self.msi.irqs[self.interrupt_map[k]].eq(v)
 
+        # flash the led on pcie clock
+        counter = Signal(32)
+        self.sync.clk125 += counter.eq(counter + 1)
+        self.comb += platform.request("user_led", 0).eq(counter[26])
+
 
 def main():
     parser = argparse.ArgumentParser(description="NeTV2 LiteX PCIe SoC")


### PR DESCRIPTION
clk125 domain doesn't exist in BaseSoC.

ERROR: [Synth 8-1031] clk125_clk is not declared [lite/netv2-soc/build/gateware/top.v:7993]