### PR TITLE
Add BIST and dumping to the firmware

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -15,6 +15,8 @@ OBJECTS=isr.o \
 		encoder.o \
 		i2c.o \
 		main.o \
+		bist.o \
+                dump.o \
 		stdio_wrap.o
 
 CFLAGS += -I.

--- a/firmware/bist.c
+++ b/firmware/bist.c
@@ -10,7 +10,7 @@
 #include "ci.h"
 
 
-#define test_size 64*1024*1024
+#define test_size 128*1024*1024
 
 unsigned int ticks;
 unsigned int speed;
@@ -26,12 +26,17 @@ static void busy_wait(unsigned int ds)
 }
 
 void bist_test(void) {
+  // empty any characters pending
+  while(readchar_nonblock() != 0) {
+    printf( "readchar_nonblock(): %d\n", readchar_nonblock() );
+    printf( "emptying buffer: %02x\n", (unsigned int) uart_read() );
+  }
 	while(readchar_nonblock() == 0) {
 			// write
 			printf("writing %d Mbytes...", test_size/(1024*1024));
 			generator_reset_write(1);
 			generator_reset_write(0);
-			generator_base_write(0x10000);
+			generator_base_write(0x20000);
 			generator_length_write((test_size*8)/128);
 
 			timer0_en_write(0);
@@ -53,7 +58,7 @@ void bist_test(void) {
 			printf("reading %d Mbytes...", test_size/(1024*1024));
 			checker_reset_write(1);
 			checker_reset_write(0);
-			checker_base_write(0x10000);
+			checker_base_write(0x20000);
 			checker_length_write((test_size*8)/128);
 
 			timer0_en_write(0);

--- a/firmware/ci.c
+++ b/firmware/ci.c
@@ -148,6 +148,7 @@ static void ci_help(void)
 
 	help_memread();
 	help_memwrite();
+	wputs("");
 
 	help_debug();
 }

--- a/firmware/ci.c
+++ b/firmware/ci.c
@@ -19,7 +19,8 @@
 #include "ci.h"
 #include "encoder.h"
 #include "hdmi_out0.h"
-
+#include "bist.h"
+#include "dump.h"
 
 int status_enabled;
 
@@ -89,6 +90,14 @@ static void help_dma_reader(void)
 }
 #endif
 
+#ifdef CSR_GENERATOR_BASE
+static void help_sdram_test(void)
+{
+	wputs("sdram_test                     - Run SDRAM BIST checker");
+
+}
+#endif
+
 static void help_debug(void)
 {
 	wputs("debug mmcm                     - dump mmcm configuration");
@@ -132,6 +141,14 @@ static void ci_help(void)
 	help_dma_reader();
 	wputs("");
 #endif
+#ifdef CSR_GENERATOR_BASE
+	help_sdram_test();
+	wputs("");
+#endif
+
+	help_memread();
+	help_memwrite();
+
 	help_debug();
 }
 
@@ -676,6 +693,11 @@ void ci_service(void)
 			help_encoder();
 	}
 #endif
+#ifdef CSR_GENERATOR_BASE
+	else if(strcmp(token, "sdram_test") == 0) {
+	  bist_test();
+	}
+#endif
 #ifdef CSR_DMA_WRITER_BASE
 	else if(strcmp(token, "dma_writer") == 0) {
 		token = get_token(&str);
@@ -704,6 +726,31 @@ void ci_service(void)
 		}
 	}
 #endif
+
+	else if(strcmp(token, "mr") == 0 ) {
+	  unsigned int addr, len;
+	  char *str2;
+	  token = get_token(&str);
+	  addr = strtoul(token, NULL, 0);
+	  str2 = str;
+	  token = get_token(&str);
+	  if( str == str2 ) {
+	    len = 1;
+	  } else {
+	    len = strtoul(token, NULL, 0);
+	  }
+	  dump_mem(addr, len);
+	}
+
+	else if(strcmp(token, "mw") == 0 ) {
+	  unsigned int addr, data;
+	  token = get_token(&str);
+	  addr = strtoul(token, NULL, 0);
+	  token = get_token(&str);
+	  data = strtoul(token, NULL, 0);
+	  poke_mem(addr, data);
+	}
+
 	else if(strcmp(token, "status") == 0) {
 		token = get_token(&str);
 		if(strcmp(token, "on") == 0)

--- a/firmware/dump.c
+++ b/firmware/dump.c
@@ -1,0 +1,70 @@
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#include "stdio_wrap.h"
+
+#include <generated/csr.h>
+#include <generated/mem.h>
+
+void dump_mem(unsigned int addr, unsigned int len);
+void poke_mem(unsigned int addr, unsigned int data);
+void help_memread(void);
+void help_memwrite(void);
+
+void dump_mem(unsigned int addr, unsigned int len) {
+  int i = 0, j = 0;
+  unsigned int data;
+
+  if( len > 0x40000 ) {
+    wputs( "Warning: length over 0x10000, clipping to a reasonable length" );
+    len = 0x40000;
+  }
+
+  if( addr < 0x80000000 ) {
+    for( i = 0; i < len; i += 4 ) {
+      if( (i % 32) == 0 ) {
+	wprintf( "\n0x%08x: ", i + addr );
+      }
+      wprintf( "%08x ", *((unsigned int *) (addr + i) ) );
+    }
+    wprintf( "\n" );
+  } else {
+    // CSR space consists of bytes on word strides
+    for( i = 0; i < len * 4; i+= 16 ) {
+      if( (i % (32*4)) == 0 ) {
+	wprintf( "\n0x%08x: ", i + addr );
+      }
+      data = 0;
+      for( j = 0; j < 4; j++ ) {
+	data |= MMPTR(addr + j * 4 + i);
+	if( j < 3 )
+	  data <<= 8;
+      }
+      wprintf( "%08x ", data );
+    }
+    wprintf( "\n" );
+  }
+}
+
+void poke_mem(unsigned int addr, unsigned int data) {
+  int i = 0;
+  
+  addr &= 0xFFFFFFFC; // snap to the nearest word to avoid bus faults etc
+  wprintf( "Poking %08x into %08x\n", data, addr );
+  if( addr < 0x80000000 ) {
+    *((unsigned int *) addr) = data;
+  } else {
+    for( i = 3; i >= 0; i-- ) {
+      MMPTR(addr + i * 4) = data >> (i * 8);
+    }
+  }
+}
+
+void help_memread(void) {
+  wputs("mr <address> [<len>]; memory read only does 32-bit words");
+}
+void help_memwrite(void) {
+  wputs("mw <address> <value>; memory write only does 32-bit words");
+}
+

--- a/firmware/dump.h
+++ b/firmware/dump.h
@@ -1,0 +1,5 @@
+void dump_mem(unsigned int addr, unsigned int len);
+void poke_mem(unsigned int addr, unsigned int data);
+void help_memread(void);
+void help_memwrite(void);
+


### PR DESCRIPTION
Added a very simple dumping routine to help hexdump and/or poke files into memory. 

Automatically does something different for the CSR space (above 0x80000000), since it's a little funky.
